### PR TITLE
feat(3): Content Sections - Hero, Projects and Skills

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -265,6 +265,15 @@ section {
   align-items: center;
 }
 
+.hero__subtitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.25rem;
+}
+
 .hero__badge {
   display: inline-block;
   padding: 0.3rem 0.85rem;
@@ -369,7 +378,7 @@ section {
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.75rem;
 }
 
@@ -388,14 +397,47 @@ section {
   box-shadow: 0 12px 32px var(--color-shadow);
 }
 
-.project-card__image {
+/* Project card image: <img> with coloured div fallback */
+.project-card__img-wrap {
+  position: relative;
   height: 180px;
-  background: linear-gradient(135deg, var(--color-tag-bg) 0%, var(--color-border) 100%);
+  overflow: hidden;
+  background: var(--color-tag-bg);
+}
+
+.project-card__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-card__img-fallback {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--color-text-muted);
   font-size: 2.5rem;
+  background-color: var(--fallback-color, var(--color-accent));
+  opacity: 0.18;
+  z-index: 0;
+}
+
+/* When the real img loads successfully, hide the fallback */
+.project-card__img-wrap:has(.project-card__img[src]:not([src=""]):not([style*="display:none"]):not([style*="display: none"])) .project-card__img-fallback {
+  display: none;
+}
+
+/* The emoji sits on top of the coloured fallback */
+.project-card__img-wrap .project-card__img-fallback {
+  z-index: 1;
+  opacity: 1;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--fallback-color, var(--color-accent)) 25%, var(--color-tag-bg)),
+    color-mix(in srgb, var(--fallback-color, var(--color-accent)) 15%, var(--color-border))
+  );
 }
 
 .project-card__body {
@@ -461,7 +503,7 @@ section {
 
 .skills-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.25rem;
 }
 
@@ -503,8 +545,9 @@ section {
   transition: width 1s ease 0.2s;
 }
 
+/* Width set by JS via inline style on .skill-bar__fill when .visible is added */
 .skill-item.visible .skill-bar__fill {
-  width: var(--skill-pct, 0%);
+  /* JS sets fill.style.width = el.dataset.level + '%' */
 }
 
 /* Skills badge grid (alternative display) */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,8 +65,10 @@
         <div class="hero__content">
           <span class="hero__badge" data-animate>Available for hire</span>
 
+          <h2 class="hero__subtitle" data-animate>Full-Stack Developer</h2>
+
           <h1 class="hero__title" data-animate>
-            Hi, I'm <span>Alex Dev</span>
+            Hi, I'm <span>Jane Doe</span>
           </h1>
 
           <p class="hero__tagline" data-animate>
@@ -108,7 +110,15 @@
         <div class="projects-grid" id="projects-grid">
           <!-- Project Card 1 -->
           <article class="project-card" data-animate>
-            <div class="project-card__image" aria-hidden="true">🛒</div>
+            <div class="project-card__img-wrap">
+              <img
+                src="images/project-ecommerce.png"
+                alt="E-Commerce Platform screenshot"
+                class="project-card__img"
+                onerror="this.style.display='none'"
+              />
+              <div class="project-card__img-fallback" style="--fallback-color:#6c63ff" aria-hidden="true">🛒</div>
+            </div>
             <div class="project-card__body">
               <h3 class="project-card__title">E-Commerce Platform</h3>
               <p class="project-card__description">
@@ -122,15 +132,23 @@
                 <span class="tag">Stripe</span>
               </div>
               <div class="project-card__links">
-                <a href="https://example.com/ecommerce" target="_blank" rel="noopener">Live ↗</a>
-                <a href="https://github.com/example/ecommerce" target="_blank" rel="noopener">GitHub ↗</a>
+                <a href="https://example.com/ecommerce" target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+                <a href="https://github.com/example/ecommerce" target="_blank" rel="noopener noreferrer">View Repo ↗</a>
               </div>
             </div>
           </article>
 
           <!-- Project Card 2 -->
           <article class="project-card" data-animate>
-            <div class="project-card__image" aria-hidden="true">📋</div>
+            <div class="project-card__img-wrap">
+              <img
+                src="images/project-taskmanager.png"
+                alt="Task Management App screenshot"
+                class="project-card__img"
+                onerror="this.style.display='none'"
+              />
+              <div class="project-card__img-fallback" style="--fallback-color:#f7975a" aria-hidden="true">📋</div>
+            </div>
             <div class="project-card__body">
               <h3 class="project-card__title">Task Management App</h3>
               <p class="project-card__description">
@@ -144,15 +162,23 @@
                 <span class="tag">WebSockets</span>
               </div>
               <div class="project-card__links">
-                <a href="https://example.com/taskmanager" target="_blank" rel="noopener">Live ↗</a>
-                <a href="https://github.com/example/taskmanager" target="_blank" rel="noopener">GitHub ↗</a>
+                <a href="https://example.com/taskmanager" target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+                <a href="https://github.com/example/taskmanager" target="_blank" rel="noopener noreferrer">View Repo ↗</a>
               </div>
             </div>
           </article>
 
           <!-- Project Card 3 -->
           <article class="project-card" data-animate>
-            <div class="project-card__image" aria-hidden="true">🌤️</div>
+            <div class="project-card__img-wrap">
+              <img
+                src="images/project-weather.png"
+                alt="Weather Dashboard screenshot"
+                class="project-card__img"
+                onerror="this.style.display='none'"
+              />
+              <div class="project-card__img-fallback" style="--fallback-color:#48c8e8" aria-hidden="true">🌤️</div>
+            </div>
             <div class="project-card__body">
               <h3 class="project-card__title">Weather Dashboard</h3>
               <p class="project-card__description">
@@ -166,15 +192,23 @@
                 <span class="tag">CSS Grid</span>
               </div>
               <div class="project-card__links">
-                <a href="https://example.com/weather" target="_blank" rel="noopener">Live ↗</a>
-                <a href="https://github.com/example/weather" target="_blank" rel="noopener">GitHub ↗</a>
+                <a href="https://example.com/weather" target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+                <a href="https://github.com/example/weather" target="_blank" rel="noopener noreferrer">View Repo ↗</a>
               </div>
             </div>
           </article>
 
           <!-- Project Card 4 -->
           <article class="project-card" data-animate>
-            <div class="project-card__image" aria-hidden="true">💼</div>
+            <div class="project-card__img-wrap">
+              <img
+                src="images/project-portfolio.png"
+                alt="Developer Portfolio screenshot"
+                class="project-card__img"
+                onerror="this.style.display='none'"
+              />
+              <div class="project-card__img-fallback" style="--fallback-color:#4ecb71" aria-hidden="true">💼</div>
+            </div>
             <div class="project-card__body">
               <h3 class="project-card__title">Developer Portfolio Site</h3>
               <p class="project-card__description">
@@ -188,8 +222,8 @@
                 <span class="tag">Express</span>
               </div>
               <div class="project-card__links">
-                <a href="https://example.com/portfolio" target="_blank" rel="noopener">Live ↗</a>
-                <a href="https://github.com/example/portfolio" target="_blank" rel="noopener">GitHub ↗</a>
+                <a href="https://example.com/portfolio" target="_blank" rel="noopener noreferrer">Live Demo ↗</a>
+                <a href="https://github.com/example/portfolio" target="_blank" rel="noopener noreferrer">View Repo ↗</a>
               </div>
             </div>
           </article>
@@ -206,7 +240,7 @@
         <p class="section-subtitle" data-animate>Tools I work with day to day.</p>
 
         <div class="skills-grid">
-          <div class="skill-item" data-animate style="--skill-pct: 90%">
+          <div class="skill-item" data-animate data-level="90">
             <div class="skill-item__header">
               <span class="skill-item__name">JavaScript / TypeScript</span>
               <span class="skill-item__pct">90%</span>
@@ -214,7 +248,7 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 85%">
+          <div class="skill-item" data-animate data-level="85">
             <div class="skill-item__header">
               <span class="skill-item__name">React / Vue.js</span>
               <span class="skill-item__pct">85%</span>
@@ -222,7 +256,7 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 80%">
+          <div class="skill-item" data-animate data-level="80">
             <div class="skill-item__header">
               <span class="skill-item__name">Node.js / Express</span>
               <span class="skill-item__pct">80%</span>
@@ -230,15 +264,15 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 75%">
+          <div class="skill-item" data-animate data-level="88">
             <div class="skill-item__header">
               <span class="skill-item__name">HTML / CSS</span>
-              <span class="skill-item__pct">75%</span>
+              <span class="skill-item__pct">88%</span>
             </div>
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 70%">
+          <div class="skill-item" data-animate data-level="70">
             <div class="skill-item__header">
               <span class="skill-item__name">PostgreSQL / MongoDB</span>
               <span class="skill-item__pct">70%</span>
@@ -246,7 +280,7 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 72%">
+          <div class="skill-item" data-animate data-level="72">
             <div class="skill-item__header">
               <span class="skill-item__name">Docker / CI/CD</span>
               <span class="skill-item__pct">72%</span>
@@ -254,7 +288,7 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 65%">
+          <div class="skill-item" data-animate data-level="65">
             <div class="skill-item__header">
               <span class="skill-item__name">Python</span>
               <span class="skill-item__pct">65%</span>
@@ -262,10 +296,26 @@
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
 
-          <div class="skill-item" data-animate style="--skill-pct: 68%">
+          <div class="skill-item" data-animate data-level="78">
             <div class="skill-item__header">
               <span class="skill-item__name">Git / GitHub</span>
-              <span class="skill-item__pct">68%</span>
+              <span class="skill-item__pct">78%</span>
+            </div>
+            <div class="skill-bar"><div class="skill-bar__fill"></div></div>
+          </div>
+
+          <div class="skill-item" data-animate data-level="60">
+            <div class="skill-item__header">
+              <span class="skill-item__name">GraphQL / REST APIs</span>
+              <span class="skill-item__pct">60%</span>
+            </div>
+            <div class="skill-bar"><div class="skill-bar__fill"></div></div>
+          </div>
+
+          <div class="skill-item" data-animate data-level="55">
+            <div class="skill-item__header">
+              <span class="skill-item__name">AWS / Cloud</span>
+              <span class="skill-item__pct">55%</span>
             </div>
             <div class="skill-bar"><div class="skill-bar__fill"></div></div>
           </div>
@@ -365,7 +415,7 @@
        FOOTER
        ============================================================ -->
   <footer>
-    <p>Built with <span>♥</span> by Alex Dev &mdash; &copy; <span id="footer-year"></span></p>
+    <p>Built with <span>♥</span> by Jane Doe &mdash; &copy; <span id="footer-year"></span></p>
   </footer>
 
   <!-- Scripts -->

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -82,16 +82,23 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   /* ============================================================
-     Skill bar animation — trigger on .visible
+     Skill bar animation — IntersectionObserver reads data-level
      ============================================================ */
-  const skillItems = document.querySelectorAll('.skill-item');
+  const skillItems = document.querySelectorAll('.skill-item[data-level]');
   if ('IntersectionObserver' in window && skillItems.length) {
     const skillObserver = new IntersectionObserver(
       function (entries) {
         entries.forEach(function (entry) {
           if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
-            skillObserver.unobserve(entry.target);
+            var el = entry.target;
+            var level = parseInt(el.getAttribute('data-level'), 10) || 0;
+            var fill = el.querySelector('.skill-bar__fill');
+            if (fill) {
+              /* Animate width from 0 to data-level% */
+              fill.style.width = level + '%';
+            }
+            el.classList.add('visible');
+            skillObserver.unobserve(el);
           }
         });
       },
@@ -99,6 +106,14 @@ document.addEventListener('DOMContentLoaded', function () {
     );
     skillItems.forEach(function (el) {
       skillObserver.observe(el);
+    });
+  } else {
+    /* Fallback: set widths immediately */
+    skillItems.forEach(function (el) {
+      var level = parseInt(el.getAttribute('data-level'), 10) || 0;
+      var fill = el.querySelector('.skill-bar__fill');
+      if (fill) fill.style.width = level + '%';
+      el.classList.add('visible');
     });
   }
 

--- a/frontend/js/typing.js
+++ b/frontend/js/typing.js
@@ -2,13 +2,17 @@
 
 /* ============================================================
    Typing Effect — Hero tagline
+   Pure JS, no libraries. Uses setTimeout loops and the CSS
+   .cursor blink keyframe already defined in style.css.
+   Cycles through at least 3 tagline strings.
    ============================================================ */
 (function initTyping() {
   var phrases = [
-    'Full-Stack Developer',
-    'UI/UX Enthusiast',
-    'Open Source Contributor',
-    'Problem Solver',
+    'Building scalable web applications',
+    'Crafting clean, maintainable code',
+    'Turning ideas into products',
+    'Open source contributor',
+    'Always learning, always shipping',
   ];
 
   var el = document.getElementById('typing-text');
@@ -17,35 +21,41 @@
   var phraseIndex = 0;
   var charIndex = 0;
   var isDeleting = false;
-  var typingSpeed = 90;
-  var deletingSpeed = 50;
-  var pauseAfterPhrase = 1800;
-  var pauseBeforeType = 400;
+
+  /* Timing constants (ms) */
+  var TYPING_SPEED   = 85;
+  var DELETING_SPEED = 45;
+  var PAUSE_AFTER    = 2000;
+  var PAUSE_BEFORE   = 350;
 
   function type() {
     var currentPhrase = phrases[phraseIndex];
+    var nextDelay;
 
     if (isDeleting) {
-      el.textContent = currentPhrase.slice(0, charIndex - 1);
-      charIndex--;
+      charIndex -= 1;
+      el.textContent = currentPhrase.slice(0, charIndex);
+      nextDelay = DELETING_SPEED;
     } else {
-      el.textContent = currentPhrase.slice(0, charIndex + 1);
-      charIndex++;
+      charIndex += 1;
+      el.textContent = currentPhrase.slice(0, charIndex);
+      nextDelay = TYPING_SPEED;
     }
-
-    var delay = isDeleting ? deletingSpeed : typingSpeed;
 
     if (!isDeleting && charIndex === currentPhrase.length) {
-      delay = pauseAfterPhrase;
+      /* Finished typing — pause then start deleting */
       isDeleting = true;
+      nextDelay = PAUSE_AFTER;
     } else if (isDeleting && charIndex === 0) {
+      /* Finished deleting — advance to next phrase */
       isDeleting = false;
       phraseIndex = (phraseIndex + 1) % phrases.length;
-      delay = pauseBeforeType;
+      nextDelay = PAUSE_BEFORE;
     }
 
-    setTimeout(type, delay);
+    setTimeout(type, nextDelay);
   }
 
-  setTimeout(type, pauseBeforeType);
+  /* Initial delay before first phrase starts */
+  setTimeout(type, PAUSE_BEFORE);
 })();


### PR DESCRIPTION
Feature #3 for Issue #1

Populates the three content sections inside the existing frontend/index.html shell.

### Hero
- Name: **Jane Doe** (placeholder)
- Subtitle: "Full-Stack Developer" shown above the h1
- `typing.js`: 5 developer-role phrases cycling with pure `setTimeout` loops; CSS `.cursor` blink keyframe; no libraries

### Projects
- Grid: `repeat(auto-fit, minmax(280px, 1fr))` — changed from `auto-fill`
- 4 hard-coded cards each with: `<img src>` + `onerror` hides on failure; coloured `.project-card__img-fallback` div; title, description, tech tags; **Live Demo** and **View Repo** links

### Skills
- 10 named skills each with `data-level` attribute (55-90)
- `IntersectionObserver` in `main.js` reads `data-level` on entry and sets `fill.style.width = level + '%'`

### Acceptance criteria
- [x] Typing effect cycles 5 strings with cursor blink
- [x] 4 project cards in responsive grid
- [x] 10 skills displayed with IO-triggered bar animation
- [x] No JS errors
- [x] Works in dark and light theme

---
*Created by Antigravity Dev Agent*