### PR TITLE
feat(2): SVG placeholder images for project cards

### DIFF
--- a/backend/data/projects.json
+++ b/backend/data/projects.json
@@ -3,7 +3,7 @@
     "id": 1,
     "title": "E-Commerce Platform",
     "description": "A full-stack e-commerce application with product listings, shopping cart, and secure checkout. Built with React, Node.js, and PostgreSQL.",
-    "image": "/images/project-ecommerce.png",
+    "image": "/images/project-ecommerce.svg",
     "tags": ["React", "Node.js", "PostgreSQL", "Stripe"],
     "liveUrl": "https://example.com/ecommerce",
     "repoUrl": "https://github.com/example/ecommerce"
@@ -12,7 +12,7 @@
     "id": 2,
     "title": "Task Management App",
     "description": "A collaborative task manager with real-time updates, drag-and-drop boards, and team assignments. Powered by Vue.js and Firebase.",
-    "image": "/images/project-taskmanager.png",
+    "image": "/images/project-taskmanager.svg",
     "tags": ["Vue.js", "Firebase", "Tailwind CSS", "WebSockets"],
     "liveUrl": "https://example.com/taskmanager",
     "repoUrl": "https://github.com/example/taskmanager"
@@ -21,7 +21,7 @@
     "id": 3,
     "title": "Weather Dashboard",
     "description": "An interactive weather dashboard displaying real-time forecasts, historical data charts, and location-based alerts using the OpenWeather API.",
-    "image": "/images/project-weather.png",
+    "image": "/images/project-weather.svg",
     "tags": ["JavaScript", "Chart.js", "REST API", "CSS Grid"],
     "liveUrl": "https://example.com/weather",
     "repoUrl": "https://github.com/example/weather"
@@ -30,7 +30,7 @@
     "id": 4,
     "title": "Developer Portfolio Site",
     "description": "This very portfolio — a responsive single-page site with smooth animations, dark/light theme toggle, and a contact form backed by an Express API.",
-    "image": "/images/project-portfolio.png",
+    "image": "/images/project-portfolio.svg",
     "tags": ["HTML", "CSS", "JavaScript", "Express"],
     "liveUrl": "https://example.com/portfolio",
     "repoUrl": "https://github.com/example/portfolio"

--- a/frontend/images/project-ecommerce.svg
+++ b/frontend/images/project-ecommerce.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 340">
+  <rect width="600" height="340" fill="#6c63ff"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="80">🛒</text>
+</svg>

--- a/frontend/images/project-portfolio.svg
+++ b/frontend/images/project-portfolio.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 340">
+  <rect width="600" height="340" fill="#5cb85c"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="80">💼</text>
+</svg>

--- a/frontend/images/project-taskmanager.svg
+++ b/frontend/images/project-taskmanager.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 340">
+  <rect width="600" height="340" fill="#f7975a"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="80">📋</text>
+</svg>

--- a/frontend/images/project-weather.svg
+++ b/frontend/images/project-weather.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 340">
+  <rect width="600" height="340" fill="#48c8e8"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="80">🌤️</text>
+</svg>


### PR DESCRIPTION
## Feature 2: SVG placeholder images for project cards

Closes part of #6

### What changed

- **`frontend/images/`** (NEW directory, 4 SVG files): Each SVG is 600×340 viewBox with a solid colour background rect and a centred emoji via SVG `<text>` element (font-size 80, dominant-baseline middle, text-anchor middle, positioned at x=50% y=55%)
  - `project-ecommerce.svg` — `#6c63ff` background, 🛒
  - `project-taskmanager.svg` — `#f7975a` background, 📋
  - `project-weather.svg` — `#48c8e8` background, 🌤️
  - `project-portfolio.svg` — `#5cb85c` background, 💼
- **`backend/data/projects.json`** (MODIFIED): Updated all 4 `image` fields from `.png` to `.svg` paths

### Acceptance criteria checklist

- [x] All 4 SVG files created in `frontend/images/`
- [x] Each SVG: correct colour, centred emoji, 600×340 viewBox
- [x] `projects.json` image paths point to `.svg` files (no `.png` refs remain)
- [x] No broken-image browser icons when backend serves files

---
*Created by Antigravity Dev Agent*