### PR TITLE
feat(3): Remove hardcoded localhost API URL from contact form

### DIFF
--- a/frontend/js/contact.js
+++ b/frontend/js/contact.js
@@ -4,13 +4,23 @@
    Contact Form — Feature 4: Contact Form Frontend Integration
    - Client-side validation (all fields required, email regex)
    - Loading state on submit button prevents double-submission
-   - POST JSON to http://localhost:3000/api/contact
+   - POST JSON to API_BASE + /api/contact (runtime-resolved)
    - 200 → clear form + green success banner
    - 400 → display returned error array as red error message
    - Network failure → generic red error
    - All states themed via CSS custom properties
    ============================================================ */
 (function initContactForm() {
+
+  /* ---- Runtime API base URL (dev: localhost:3000, prod: same origin) ---- */
+  var API_BASE = (function () {
+    var h = window.location.hostname;
+    if (h === 'localhost' || h === '127.0.0.1') {
+      return 'http://localhost:3000';
+    }
+    return window.location.origin;
+  })();
+
   var form      = document.getElementById('contact-form');
   if (!form) return;
 
@@ -124,7 +134,7 @@
     /* --- Loading state — prevents double submission --- */
     setLoading(true);
 
-    fetch('http://localhost:3000/api/contact', {
+    fetch(API_BASE + '/api/contact', {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
       body:    JSON.stringify({ name: name, email: email, message: message }),


### PR DESCRIPTION
## Feature 3: Remove hardcoded localhost API URL from contact form

Closes part of #6

### What changed

- **`frontend/js/contact.js`** (MODIFIED):
  - Added `API_BASE` IIFE at the top of `initContactForm()` — resolves to `http://localhost:3000` when `hostname` is `localhost`/`127.0.0.1`, else `window.location.origin`
  - Replaced `fetch('http://localhost:3000/api/contact', ...)` with `fetch(API_BASE + '/api/contact', ...)`
  - Updated file header comment

### Consistency note

`projects.js` (Feature 1, already merged) uses the identical `API_BASE` IIFE pattern. Both frontend JS files are now consistent — zero hardcoded `localhost:3000` strings remain in any fetch call.

### Acceptance criteria checklist

- [x] No hardcoded `localhost:3000` in any `fetch()` call in `frontend/js/`
- [x] `API_BASE` resolves to `http://localhost:3000` on localhost
- [x] `API_BASE` resolves to `window.location.origin` on any other hostname
- [x] Pattern is consistent between `contact.js` and `projects.js`
- [x] No shared config file — IIFE defined inline in each file

---
*Created by Antigravity Dev Agent*